### PR TITLE
Feature - Init server at start

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,15 +14,6 @@
       "preLaunchTask": "${defaultBuildTask}"
     },
     {
-      "name": "Run Server",
-      "type": "node",
-      "request": "launch",
-      "cwd": "${workspaceFolder}/apps/server",
-      "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "start"],
-      "autoAttachChildProcesses": true
-    },
-    {
       "name": "Extension Tests",
       "type": "extensionHost",
       "request": "launch",
@@ -35,13 +26,6 @@
         "${workspaceFolder}/apps/extension/dist/**/*.js"
       ],
       "preLaunchTask": "tasks: watch-tests"
-    }
-  ],
-  "compounds": [
-    {
-      "name": "Run Extension and Server",
-      "configurations": ["Run Server", "Run Extension"],
-      "default": true
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,5 +36,12 @@
       ],
       "preLaunchTask": "tasks: watch-tests"
     }
+  ],
+  "compounds": [
+    {
+      "name": "Run Extension and Server",
+      "configurations": ["Run Server", "Run Extension"],
+      "default": true
+    }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,15 @@
       "preLaunchTask": "${defaultBuildTask}"
     },
     {
+      "name": "Run Server",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/apps/server",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "start"],
+      "autoAttachChildProcesses": true
+    },
+    {
       "name": "Extension Tests",
       "type": "extensionHost",
       "request": "launch",

--- a/apps/extension/src/extension.ts
+++ b/apps/extension/src/extension.ts
@@ -63,6 +63,20 @@ export async function activate(context: vscode.ExtensionContext) {
     console.log(`Node.js version: ${stdout.trim()}`);
   });
 
+  cp.exec("npx @boostercloud/booster-tutor-server", (error, stdout, stderr) => {
+    if (error) {
+      console.error(
+        `Error executing 'npx @boostercloud/booster-tutor-server': ${error.message}`
+      );
+      return;
+    }
+    if (stderr) {
+      console.error(`Error message: ${stderr}`);
+      return;
+    }
+    console.log(`Server started: ${stdout.trim()}`);
+  });
+
   // eslint-disable-next-line no-unused-vars
   const disposable = vscode.window.onDidChangeActiveTextEditor((_editor) => {});
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@boostercloud/booster-tutor-server",
-  "version": "0.0.1",
+  "version": "0.0.4",
   "description": "",
   "main": "./dist/server.js",
+  "bin": {
+    "booster-tutor-server": "./dist/server.js"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "start": "npm run build && node ./dist/server.js",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "server",
+  "name": "@boostercloud/booster-tutor-server",
   "version": "0.0.1",
   "description": "",
   "main": "./dist/server.js",

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import fastify from "fastify";
 
 const server = fastify();


### PR DESCRIPTION
This PR enables the ability to start both the server and the extension simultaneously at launchtime. 

**Update**
Removed the `launch.json` approach in favor of calling the server via `npx` on the extension startup

<img width="465" alt="image" src="https://github.com/boostercloud/booster-tutor/assets/9259053/67e51700-5d7e-4a15-921c-54f8c8cc1097">
